### PR TITLE
Redirect old links to new pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,6 +146,7 @@ module.exports = {
     [
       "@docusaurus/plugin-client-redirects",
       {
+        fromExtensions: ["html"],
         redirects: [
           {
             to: "/tutorials/mint-etherscan",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -246,6 +246,28 @@ module.exports = {
             to: "/oracle/adding-price-id",
             from: ["/uma/oracle/adding_a_price_identifier.html"],
           },
+          // developer reference
+          {
+            to: "/dev-ref/addresses",
+            from: ["/uma/developer_reference/contract_addresses.html"]
+          },
+          {
+            to: "/dev-ref/bug-bounty",
+            from: ["/uma/developer_reference/bug_bounty.html"]
+          },
+          // community
+          {
+            to: "/community/events",
+            from: ["/uma/community/previous_and_upcoming_events.html"]
+          },
+          {
+            to: "/community/press",
+            from: ["/uma/community/interviews_and_press.html"]
+          },
+          {
+            to: "/community/blog-posts",
+            from: ["/uma/community/blog_posts.html"]
+          },
         ],
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,19 +220,6 @@ module.exports = {
             to: "/oracle/mainnet-info",
             from: ["/uma/oracle/mainnet_deployment_info.html"],
           },
-          // governance
-          {
-            to: "/oracle/uma-holders",
-            from: ["/uma/oracle/UMA_token_holder_responsibilities.html"],
-          },
-          {
-            to: "/oracle/umips",
-            from: ["/uma/oracle/UMIPs.html"],
-          },
-          {
-            to: "/oracle/adding-price-id",
-            from: ["/uma/oracle/adding_a_price_identifier.html"],
-          },
           // tutorials (oracle)
           {
             to: "/tutorials/voting-uma",
@@ -245,6 +232,19 @@ module.exports = {
           {
             to: "/tutorials/dvm-integration",
             from: ["/uma/oracle/integrating_the_dvm.html"],
+          },
+          // governance
+          {
+            to: "/oracle/uma-holders",
+            from: ["/uma/oracle/UMA_token_holder_responsibilities.html"],
+          },
+          {
+            to: "/oracle/umips",
+            from: ["/uma/oracle/UMIPs.html"],
+          },
+          {
+            to: "/oracle/adding-price-id",
+            from: ["/uma/oracle/adding_a_price_identifier.html"],
           },
         ],
       },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,6 +149,22 @@ module.exports = {
         fromExtensions: ["html"],
         redirects: [
           {
+            to: "/",
+            from: ["/uma/index.html"],
+          },
+          {
+            to: "/getting-started/overview",
+            from: ["/uma/getting_started/architecture_overview.html"],
+          },
+          {
+            to: "/getting-started/synthetic-tokens",
+            from: ["/uma/getting_started/priceless_defi_contracts.html"],
+          },
+          {
+            to: "/getting-started/oracle",
+            from: ["/uma/getting_started/uma_oracle_design.html"],
+          },
+          {
             to: "/tutorials/mint-etherscan",
             from: ["/uma/synthetic_tokens/mint_tokens_via_etherscan.html"],
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,6 +220,19 @@ module.exports = {
             to: "/oracle/mainnet-info",
             from: ["/uma/oracle/mainnet_deployment_info.html"],
           },
+          // governance
+          {
+            to: "/oracle/uma-holders",
+            from: ["/uma/oracle/UMA_token_holder_responsibilities.html"],
+          },
+          {
+            to: "/oracle/umips",
+            from: ["/uma/oracle/UMIPs.html"],
+          },
+          {
+            to: "/oracle/adding-price-id",
+            from: ["/uma/oracle/adding_a_price_identifier.html"],
+          },
         ],
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -233,6 +233,19 @@ module.exports = {
             to: "/oracle/adding-price-id",
             from: ["/uma/oracle/adding_a_price_identifier.html"],
           },
+          // tutorials (oracle)
+          {
+            to: "/tutorials/voting-uma",
+            from: ["/uma/oracle/voting_with_uma_tokens.html"],
+          },
+          {
+            to: "/tutorials/voting-2key",
+            from: ["/uma/oracle/voting_with_UMA_2-key_contract.html"],
+          },
+          {
+            to: "/tutorials/dvm-integration",
+            from: ["/uma/oracle/integrating_the_dvm.html"],
+          },
         ],
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -178,6 +178,23 @@ module.exports = {
             to: "/synthetic-tokens/known-issues",
             from: ["/uma/synthetic_tokens/known_issues.html"],
           },
+          // tutorials (synthetic tokens)
+          {
+            to: "/tutorials/setup",
+            from: ["/uma/synthetic_tokens/prerequisites.html"],
+          },
+          {
+            to: "/tutorials/mint-locally",
+            from: ["/uma/synthetic_tokens/creating_from_truffle.html"],
+          },
+          {
+            to: "/tutorials/cli-tool",
+            from: ["/uma/synthetic_tokens/using_the_uma_sponsor_cli_tool.html"],
+          },
+          {
+            to: "/tutorials/bots",
+            from: ["/uma/synthetic_tokens/liquidation.html"],
+          },
           {
             to: "/tutorials/mint-etherscan",
             from: ["/uma/synthetic_tokens/mint_tokens_via_etherscan.html"],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,4 +142,17 @@ module.exports = {
     ],
   ],
   stylesheets: ["https://use.typekit.net/jll8euv.css"],
+  plugins: [
+    [
+      "@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          {
+            to: "/tutorials/mint-etherscan",
+            from: ["/uma/synthetic_tokens/mint_tokens_via_etherscan.html"],
+          },
+        ],
+      },
+    ],
+  ],
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,7 +150,10 @@ module.exports = {
         redirects: [
           {
             to: "/",
-            from: ["/uma/index.html"],
+            from: [
+              "/uma/index.html",
+              "/uma/community/connecting_with_UMA.html",
+            ],
           },
           // getting started
           {
@@ -249,24 +252,24 @@ module.exports = {
           // developer reference
           {
             to: "/dev-ref/addresses",
-            from: ["/uma/developer_reference/contract_addresses.html"]
+            from: ["/uma/developer_reference/contract_addresses.html"],
           },
           {
             to: "/dev-ref/bug-bounty",
-            from: ["/uma/developer_reference/bug_bounty.html"]
+            from: ["/uma/developer_reference/bug_bounty.html"],
           },
           // community
           {
             to: "/community/events",
-            from: ["/uma/community/previous_and_upcoming_events.html"]
+            from: ["/uma/community/previous_and_upcoming_events.html"],
           },
           {
             to: "/community/press",
-            from: ["/uma/community/interviews_and_press.html"]
+            from: ["/uma/community/interviews_and_press.html"],
           },
           {
             to: "/community/blog-posts",
-            from: ["/uma/community/blog_posts.html"]
+            from: ["/uma/community/blog_posts.html"],
           },
         ],
       },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,6 +152,7 @@ module.exports = {
             to: "/",
             from: ["/uma/index.html"],
           },
+          // getting started
           {
             to: "/getting-started/overview",
             from: ["/uma/getting_started/architecture_overview.html"],
@@ -163,6 +164,19 @@ module.exports = {
           {
             to: "/getting-started/oracle",
             from: ["/uma/getting_started/uma_oracle_design.html"],
+          },
+          // synthetic tokens
+          {
+            to: "/synthetic-tokens/explainer",
+            from: ["/uma/synthetic_tokens/explainer.html"],
+          },
+          {
+            to: "/synthetic-tokens/glossary",
+            from: ["/uma/synthetic_tokens/glossary.html"],
+          },
+          {
+            to: "/synthetic-tokens/known-issues",
+            from: ["/uma/synthetic_tokens/known_issues.html"],
           },
           {
             to: "/tutorials/mint-etherscan",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -238,15 +238,15 @@ module.exports = {
           },
           // governance
           {
-            to: "/oracle/uma-holders",
+            to: "/governance/uma-holders",
             from: ["/uma/oracle/UMA_token_holder_responsibilities.html"],
           },
           {
-            to: "/oracle/umips",
+            to: "/governance/umips",
             from: ["/uma/oracle/UMIPs.html"],
           },
           {
-            to: "/oracle/adding-price-id",
+            to: "/governance/adding-price-id",
             from: ["/uma/oracle/adding_a_price_identifier.html"],
           },
           // developer reference

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -199,6 +199,27 @@ module.exports = {
             to: "/tutorials/mint-etherscan",
             from: ["/uma/synthetic_tokens/mint_tokens_via_etherscan.html"],
           },
+          // oracle
+          {
+            to: "/oracle/tech-architecture",
+            from: ["/uma/oracle/technical_architecture.html"],
+          },
+          {
+            to: "/oracle/econ-architecture",
+            from: ["/uma/oracle/economic_architecture.html"],
+          },
+          {
+            to: "/oracle/dvm-interface",
+            from: ["/uma/oracle/dvm_interfaces.html"],
+          },
+          {
+            to: "/oracle/known-issues",
+            from: ["/uma/oracle/known_issues.html"],
+          },
+          {
+            to: "/oracle/mainnet-info",
+            from: ["/uma/oracle/mainnet_deployment_info.html"],
+          },
         ],
       },
     ],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.58",
+    "@docusaurus/plugin-client-redirects": "^2.0.0-alpha.58",
     "@docusaurus/preset-classic": "^2.0.0-alpha.58",
     "clsx": "^1.1.1",
     "react": "^16.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,6 +934,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.6":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1052,6 +1059,17 @@
     remark-emoji "^2.1.0"
     stringify-object "^3.3.0"
     unist-util-visit "^2.0.2"
+
+"@docusaurus/plugin-client-redirects@^2.0.0-alpha.58":
+  version "2.0.0-alpha.58"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.0-alpha.58.tgz#4de7eefbdaaae897a501ac4d128fcd5c9960a2de"
+  integrity sha512-7p59dKI7QVxAt/4HISpjJ6l+ayupstBzxFPfqdAmHZiaL7JE9Dm6IWgfxaACWsUT9+854AHtp0bsKyJxv/GAzg==
+  dependencies:
+    "@docusaurus/types" "^2.0.0-alpha.58"
+    "@docusaurus/utils" "^2.0.0-alpha.58"
+    eta "^1.1.1"
+    globby "^10.0.1"
+    yup "^0.29.0"
 
 "@docusaurus/plugin-content-blog@^2.0.0-alpha.58":
   version "2.0.0-alpha.58"
@@ -4058,6 +4076,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+fn-name@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-3.0.0.tgz#0596707f635929634d791f452309ab41558e3c5c"
+  integrity sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA==
+
 follow-redirects@^1.0.0:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
@@ -5527,6 +5550,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.11:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -7393,6 +7421,11 @@ prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+property-expr@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.2.tgz#fff2a43919135553a3bc2fdd94bdb841965b2330"
+  integrity sha512-bc/5ggaYZxNkFKj374aLbEDqVADdYaLcFo8XBkishUWbaAdjlphaBFns9TvRA2pUseVL/wMFmui9X3IdNDU37g==
+
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.5.0.tgz#4dc075d493061a82e2b7d096f406e076ed859943"
@@ -8750,6 +8783,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+synchronous-promise@^2.0.10:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.13.tgz#9d8c165ddee69c5a6542862b405bc50095926702"
+  integrity sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -8902,6 +8940,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -9637,6 +9680,19 @@ yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yup@^0.29.0:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.29.1.tgz#35d25aab470a0c3950f66040ba0ff4b1b6efe0d9"
+  integrity sha512-U7mPIbgfQWI6M3hZCJdGFrr+U0laG28FxMAKIgNvgl7OtyYuUoc4uy9qCWYHZjh49b8T7Ug8NNDdiMIEytcXrQ==
+  dependencies:
+    "@babel/runtime" "^7.9.6"
+    fn-name "~3.0.0"
+    lodash "^4.17.15"
+    lodash-es "^4.17.11"
+    property-expr "^2.0.2"
+    synchronous-promise "^2.0.10"
+    toposort "^2.0.2"
 
 zepto@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Using the Docusaurus redirection plugin: https://v2.docusaurus.io/docs/using-plugins/#docusaurusplugin-client-redirects

Note to devs: the effects of this plugin only appear after you build it (i.e. `yarn build`) and will not work in dev mode.

My current testing method is:

1. `yarn build`
2. `python3 -m http.server --directory ./build/` to serve the built files
3. Go to your browser and try out the link (e.g. `http://0.0.0.0:8000/uma/synthetic_tokens/mint_tokens_via_etherscan.html`)

Sections I need to do redirects for:

- [x] getting started
- [x] synthetic tokens
- [x] oracle
- [x] governance
- [x] tutorials (synthetic tokens)
- [x] tutorials (oracle)
- [x] community
- [x] developer reference