### PR TITLE
fix: sample env emp_address change to correct yusd emp contract addr

### DIFF
--- a/docs/community/liquidation-opportunity-program.md
+++ b/docs/community/liquidation-opportunity-program.md
@@ -48,7 +48,7 @@ the [tutorial](tutorials/bots.md) for appropriate values.
 
 ```shell title="example.env"
 POLLING_DELAY=30000
-EMP_ADDRESS=0xDe15ae6E8CAA2fDa906b1621cF0F7296Aa79d9f1
+EMP_ADDRESS=0xb56C5f1fB93b1Fbd7c473926c87B6B9c4d0e21d5
 COMMAND=npx truffle exec ../liquidator/index.js --network kovan_mnemonic
 MNEMONIC=sail chuckle school attitude symptom tenant fragile patch ring immense main rapid
 PRICE_FEED_CONFIG={"type":"medianizer","apiKey":"YOUR_API_KEY","pair":"ethbtc","lookback":7200,"minTimeBetweenUpdates":60,"medianizedFeeds":[{"type":"cryptowatch","exchange":"coinbase-pro"},{"type":"cryptowatch","exchange":"binance"},{"type":"cryptowatch","exchange":"bitstamp"}]}


### PR DESCRIPTION
Since this doc is in context of yUSD liquidation opp, it makes sense that the env should have correct emp address.